### PR TITLE
guard against AttributeError exception in get_device_list

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,7 +79,10 @@ def get_builds():
         raise UpstreamApiException('Unable to contact upstream API')
 
 def get_device_list():
-    return get_builds().keys()
+    try:
+        return get_builds().keys()
+    except AttributeError:
+        return {}
 
 def get_device(device):
     builds = get_builds()


### PR DESCRIPTION
when you provide an empty builds.json
```
[]
```
then the whole updater will crash with the following exception when trying to access it
```
  File "/home/update/updater/app.py", line 82, in get_device_list
    return builds.keys()
AttributeError: 'list' object has no attribute 'keys'
```