### PR TITLE
Don't load whole file into memory in gen_mirror_json

### DIFF
--- a/gen_mirror_json.py
+++ b/gen_mirror_json.py
@@ -13,14 +13,16 @@ FILE_BASE = sys.argv[1]
 builds = {}
 
 for f in [os.path.join(dp, f) for dp, dn, fn in os.walk(FILE_BASE) for f in fn]:
-    data = open(f).read()
+    data = open(f)
     filename = f.split('/')[-1]
     # lineage-14.1-20171129-nightly-hiaeul-signed.zip
     _, version, builddate, buildtype, device = os.path.splitext(filename)[0].split('-')
     print('hashing sha256 for {}'.format(filename), file=sys.stderr)
-    sha256 = hashlib.sha256(data).hexdigest()
+    sha256 = hashlib.sha256()
+    for buf in iter(lambda : data.read(128 * 1024), b''):
+        sha256.update(buf)
     builds.setdefault(device, []).append({
-        'sha256': hashlib.sha256(data).hexdigest(),
+        'sha256': sha256.hexdigest(),
         'size': os.path.getsize(f),
         'date': '{}-{}-{}'.format(builddate[0:4], builddate[4:6], builddate[6:8]),
         'filename': filename,


### PR DESCRIPTION
* Some systems don't have enough memory to load
  whole installer package.

* Before:
```
luk@luk-rpi:~/test$ dd if=/dev/urandom of=builds/lineage-14.1-20171129-nightly-hiaeul.zip bs=64M count=16 iflag=fullblock
16+0 records in
16+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 95.8753 s, 11.2 MB/s
luk@luk-rpi:~/test$ sha256sum builds/lineage-14.1-20171129-nightly-hiaeul.zip
05b160d282c62d240003c7e61774a654e3857d44753db4229a6ba7b4adbed544  builds/lineage-14.1-20171129-nightly-hiaeul.zip
luk@luk-rpi:~/test$ python3 gen_mirror_json.py /home/luk/test/builds/
Traceback (most recent call last):
  File "gen_mirror_json.py", line 16, in <module>
    data = open(f).read()
MemoryError
```

* After:
```
luk@luk-rpi:~/test$ python3 gen_mirror_json.py /home/luk/test/builds/
hashing sha256 for lineage-14.1-20171129-nightly-hiaeul.zip
{
    "hiaeul": [
        {
            "date": "2017-11-29",
            "filename": "lineage-14.1-20171129-nightly-hiaeul.zip",
            "filepath": "lineage-14.1-20171129-nightly-hiaeul.zip",
            "sha256": "05b160d282c62d240003c7e61774a654e3857d44753db4229a6ba7b4adbed544",
            "size": 1073741824,
            "type": "nightly",
            "version": "14.1"
        }
    ]
}
```