### PR TITLE
bug fix on gen_mirror file, re import added for functionality and tim…

### DIFF
--- a/gen_mirror_json.py
+++ b/gen_mirror_json.py
@@ -26,7 +26,7 @@ for f in [os.path.join(dp, f) for dp, dn, fn in os.walk(FILE_BASE) for f in fn]:
     for buf in iter(lambda : data.read(128 * 1024), b''):
         sha256.update(buf)
 
-        BASE_PATH = "home/user/updater/builds/" #this path is based on your system and you should modify this
+        BASE_PATH = "home/user/updater/builds/" 
         filepath = filename
 
         try:

--- a/gen_mirror_json.py
+++ b/gen_mirror_json.py
@@ -25,11 +25,16 @@ for f in [os.path.join(dp, f) for dp, dn, fn in os.walk(FILE_BASE) for f in fn]:
     sha256 = hashlib.sha256()
     for buf in iter(lambda : data.read(128 * 1024), b''):
         sha256.update(buf)
+
+        BASE_PATH = "home/user/updater/builds/" #this path is based on your system and you should modify this
+        filepath = filename
+
         try:
             with zipfile.ZipFile('{}{}'.format(BASE_PATH, filepath), 'r') as update_zip:
-                build_prop = update_zip.read('system/build.prop').decode('utf-8')
-                timestamp = int(re.findall('ro.build.date.utc=([0-9]+)', build_prop)[0])
-        except:
+                build_prop = update_zip.read('META-INF/com/android/metadata').decode('utf-8')
+                timestamp = (re.findall('post-timestamp=([0-9]+)', build_prop)[0])
+        except Exception as e:
+            print(e)
             timestamp = int(mktime(datetime.strptime(builddate, '%Y%m%d').timetuple()))
 
     builds.setdefault(device, []).append({

--- a/gen_mirror_json.py
+++ b/gen_mirror_json.py
@@ -41,7 +41,7 @@ for f in [os.path.join(dp, f) for dp, dn, fn in os.walk(FILE_BASE) for f in fn]:
         'sha256': sha256.hexdigest(),
         'size': os.path.getsize(f),
         'date': '{}-{}-{}'.format(builddate[0:4], builddate[4:6], builddate[6:8]),
-        'datetime': timestamp,
+        'datetime': int(timestamp),
         'filename': filename,
         'filepath': f.replace(FILE_BASE, ''),
         'version': version,


### PR DESCRIPTION
to find the build date and the timestamp, you can't find it in 'system/build.prop'
when you create Full or Incremental OTA package, this information exist inside 'META-INF/com/android/metadata'
there is a part called 'post-timetsamp' which is the timestamp of the created ota package.

also 're' was not imported
