### PR TITLE
Offer Lineage Recovery unless explicitly disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ devices.json is an array of objects, each with several fields:
 * `name`: the user-friendly name of the device - e.g. `Galaxy S III (Intl)`. Long values will overflow and look bad,
 so limit this to around 25 characters.
 * `has_recovery`: (*optional*) whether or not the device has a separate recovery partition. Defaults to `true`.
-* `lineage_recovery`: (*optional*) whether or not to offer Lineage recovery downloads for this device. Defaults to `false`.
+* `lineage_recovery`: (*optional*) whether or not to offer Lineage recovery downloads for this device. Defaults to `true`.
 
 Development set up:
 ---

--- a/app.py
+++ b/app.py
@@ -122,7 +122,7 @@ def get_oem_device_mapping():
         if device['model'] in devices:
             oem_to_device.setdefault(device['oem'], []).append(device)
             device_to_oem[device['model']] = device['oem']
-            offer_recovery[device['model']] = device.get('lineage_recovery', False)
+            offer_recovery[device['model']] = device.get('lineage_recovery', True)
     return oem_to_device, device_to_oem, offer_recovery
 
 @cache.memoize()


### PR DESCRIPTION
We broke this while trying to change the default setting in `hudson`.