### PR TITLE
app: fix lineage_recovery checking logic regression

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,7 +111,7 @@ def web_device(device):
     oems = get_oems()
     device_data = get_device_data(device)
     roms = get_device_builds(device)[::-1]
-    has_recovery = any([True for rom in roms if 'recovery' in rom]) and device_data.get('lineage_recovery', False)
+    has_recovery = any([True for rom in roms if 'recovery' in rom]) and device_data.get('lineage_recovery', True)
 
     return render_template('device.html', oems=oems, active_device_data=device_data,
                            roms=roms, has_recovery=has_recovery,


### PR DESCRIPTION
Merge at 417a4d9272e80eee40195fd4643f82bf3ea8ef1d did not account for the flipping of default lineage_recovery setting, which accidentally reverted dfa05780f020e029393f3d48b58c78f8101d9aa8.
    
Re-flip default to True.