### PR TITLE
Avoid `gen_mirror_json.py` `sha256.update(buf)` *TypeError: Strings must be encoded beforehashing*

### DIFF
--- a/gen_mirror_json.py
+++ b/gen_mirror_json.py
@@ -17,7 +17,7 @@ FILE_BASE = sys.argv[1]
 builds = {}
 
 for f in [os.path.join(dp, f) for dp, dn, fn in os.walk(FILE_BASE) for f in fn]:
-    data = open(f)
+    data = open(f, 'rb')
     filename = f.split('/')[-1]
     # lineage-14.1-20171129-nightly-hiaeul-signed.zip
     _, version, builddate, buildtype, device = os.path.splitext(filename)[0].split('-')


### PR DESCRIPTION
Empty build file triggers the issue notably.

Personal notes: https://codeberg.org/Benjamin_Loison/lineageos-infra_updater/issues/1#issuecomment-9254189